### PR TITLE
Convert displayed price to nim upon checkout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ After an order is submitted via the Nimiq payment method, the order is placed "o
 Transactions need to be validated manually with a *Validate Transactions* bulk action from the *Orders* admin page.
 When a transaction is validated, the order status is set to "processing".
 
-## Limitations
-
-### No automatic currency conversion!
-**This plugin does not currently include automatic currency conversion and requires the currency of the webshop to be set to NIM!**
-The currency setup is included in this plugin and NIM will be available to select under
-"WooCommerce &gt; Settings &gt; General &gt; Currency options" after activating this plugin.
-Update: [Automatic currency conversion is coming!](https://github.com/nimiq/woocommerce-gateway-nimiq/pull/14)
-
 ## Installation
 
 1. Be sure you're running WooCommerce 3.0 or higher in your shop.
@@ -24,11 +16,14 @@ Update: [Automatic currency conversion is coming!](https://github.com/nimiq/wooc
 3. Activate the plugin through the **Plugins** menu in WordPress
 4. Go to **WooCommerce &gt; Settings &gt; Payments** and select the "Nimiq" method to configure this plugin
 
-**Can I improve and fork this?**
-Please do! Issues and pull requests are very welcome! Or just adapt the plugin to your needs in a fork!
+## Automatic Currency Conversion
 
-**What is the text domain for translations?**
-The text domain is `wc-gateway-nimiq`.
+This plugin supports automatically converting from your store currency to NIM
+upon checkout. Here is a list of supported currencies for the available conversion
+services:
+
+[NimiqX](https://api.nimiqx.com/price?api_key=210b34d0df702dd157d31f118ae00420),
+[Coingecko](https://api.coingecko.com/api/v3/simple/supported_vs_currencies)
 
 ## Adding a new validation service
 
@@ -55,6 +50,12 @@ also needs to be adapted to show/hide those fields conditionally.
 - Stable Tag: 2.6.0
 - License: GPLv3
 - License URI: http://www.gnu.org/licenses/gpl-3.0.html
+
+**Can I improve and fork this?**
+Please do! Issues and pull requests are very welcome! Or just adapt the plugin to your needs in a fork!
+
+**What is the text domain for translations?**
+The text domain is `wc-gateway-nimiq`.
 
 ## Changelog
 

--- a/includes/bulk_actions.php
+++ b/includes/bulk_actions.php
@@ -111,7 +111,7 @@ function _do_bulk_validate_transactions( $gateway, $ids ) {
 			continue;
 		}
 
-		if ( $service->value() !== intval( $order->get_meta('order_total_in_nim') * 1e5 ) ) {
+		if ( $service->value() !== intval( $order->get_meta('order_total_nim') * 1e5 ) ) {
 			fail_order( $order, 'Transaction value does not match.', true );
 			$count_orders_updated++;
 			continue;

--- a/includes/bulk_actions.php
+++ b/includes/bulk_actions.php
@@ -111,7 +111,7 @@ function _do_bulk_validate_transactions( $gateway, $ids ) {
 			continue;
 		}
 
-		if ( $service->value() !== intval( $order->get_data()[ 'total' ] * 1e5 ) ) {
+		if ( $service->value() !== intval( $order->get_meta('order_total_in_nim') * 1e5 ) ) {
 			fail_order( $order, 'Transaction value does not match.', true );
 			$count_orders_updated++;
 			continue;

--- a/includes/validation_scheduler.php
+++ b/includes/validation_scheduler.php
@@ -8,8 +8,15 @@ add_action( 'wc_nimiq_scheduled_validation', 'wc_nimiq_validate_orders' );
 
 function wc_nimiq_start_validation_schedule() {
     if ( ! as_next_scheduled_action( 'wc_nimiq_scheduled_validation' ) ) {
-        $next_quarter_hour = ceil(time() / (15 * 60)) * (15 * 60);
-        $interval = 15 * 60; // 15 minutes
+	    require_once dirname( dirname( __FILE__ ) ) . DIRECTORY_SEPARATOR . 'woocommerce-gateway-nimiq.php';
+	    wc_nimiq_gateway_init();
+	    $gateway           = new WC_Gateway_Nimiq();
+	    $next_quarter_hour = ceil( time() / ( 15 * 60 ) ) * ( 15 * 60 );
+	    $interval_minutes  = $gateway->get_option( 'validation_interval' );
+	    if ( ! $interval_minutes ) {
+		    $interval_minutes = 15;
+	    }
+	    $interval = $interval_minutes * 60; // 15 minutes
         as_schedule_recurring_action( $next_quarter_hour, $interval, 'wc_nimiq_scheduled_validation' );
     }
 }

--- a/js/checkout.js
+++ b/js/checkout.js
@@ -70,6 +70,7 @@
 
     var on_signing_error = function(e) {
         console.error(e);
+        if (e.message !== 'CANCELED') alert('Error: ' + e.message);
         awaiting_transaction_signing = false;
         // Reenable checkout button
         $('button#place_order').prop('disabled', false);

--- a/js/settings.js
+++ b/js/settings.js
@@ -2,7 +2,7 @@
     'use strict';
 
     function on_price_service_change(service_slug){
-        console.debug('Validation service selected:', service_slug);
+        console.debug('Price service selected:', service_slug);
 
         // Disable all conditional fields
         var conditional_fields = [

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,27 @@
 (function($) {
     'use strict';
 
+    function on_price_service_change(service_slug){
+        console.debug('Validation service selected:', service_slug);
+
+        // Disable all conditional fields
+        var conditional_fields = [
+            '#woocommerce_nimiq_gateway_nimiqx_api_key',
+            // '#conditional_field_id',
+        ];
+        $(conditional_fields.join(',')).closest('tr').addClass('hidden');
+
+        // Enable service-specific fields
+        switch (service_slug) {
+            case 'nimiq_watch': break;
+            case 'nimiqx':
+                $('#woocommerce_nimiq_gateway_nimiqx_api_key')
+                    .closest('tr').removeClass('hidden');
+                break;
+            // case '': $('#conditional_field_id').closest('tr').removeClass('hidden'); break;
+        }
+    }
+
     function on_validation_service_change(service_slug) {
         console.debug('Validation service selected:', service_slug);
 
@@ -32,5 +53,9 @@
 
     $('#woocommerce_nimiq_gateway_validation_service').on('change', function(event) {
         on_validation_service_change(event.target.value);
+    }).change();
+
+    $('#woocommerce_nimiq_gateway_price_service').on('change', function(event) {
+        on_price_service_change(event.target.value);
     }).change();
 })(jQuery);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,61 +1,96 @@
 (function($) {
     'use strict';
 
-    function on_price_service_change(service_slug){
+    /**
+     * @param {string} service_slug
+     * @param {boolean} is_setup
+     */
+    function on_price_service_change(service_slug, is_setup){
         console.debug('Price service selected:', service_slug);
 
-        // Disable all conditional fields
+        // Disable all non-common conditional fields
         var conditional_fields = [
-            '#woocommerce_nimiq_gateway_nimiqx_api_key',
             // '#conditional_field_id',
         ];
-        $(conditional_fields.join(',')).closest('tr').addClass('hidden');
+        // $(conditional_fields.join(',')).closest('tr').addClass('hidden');
 
         // Enable service-specific fields
         switch (service_slug) {
-            case 'nimiq_watch': break;
-            case 'nimiqx':
-                $('#woocommerce_nimiq_gateway_nimiqx_api_key')
-                    .closest('tr').removeClass('hidden');
+            case 'coingecko':
                 break;
-            // case '': $('#conditional_field_id').closest('tr').removeClass('hidden'); break;
+            // case '':
+            //    $('#conditional_field_id').closest('tr').removeClass('hidden'); break;
         }
+
+        price_service = service_slug;
+        if (!is_setup) toggle_common_fields();
     }
 
-    function on_validation_service_change(service_slug) {
+    /**
+     * @param {string} service_slug
+     * @param {boolean} is_setup
+     */
+    function on_validation_service_change(service_slug, is_setup) {
         console.debug('Validation service selected:', service_slug);
 
-        // Disable all conditional fields
+        // Disable all non-common conditional fields
         var conditional_fields = [
             '#woocommerce_nimiq_gateway_jsonrpc_url',
             '#woocommerce_nimiq_gateway_jsonrpc_username',
             '#woocommerce_nimiq_gateway_jsonrpc_password',
-            '#woocommerce_nimiq_gateway_nimiqx_api_key',
             // '#conditional_field_id',
         ];
         $(conditional_fields.join(',')).closest('tr').addClass('hidden');
 
         // Enable service-specific fields
         switch (service_slug) {
-            case 'nimiq_watch': break;
+            case 'nimiq_watch':
+                break;
             case 'json_rpc':
                 $('#woocommerce_nimiq_gateway_jsonrpc_url, ' +
                   '#woocommerce_nimiq_gateway_jsonrpc_username, ' +
                   '#woocommerce_nimiq_gateway_jsonrpc_password')
                     .closest('tr').removeClass('hidden');
                 break;
-            case 'nimiqx':
-                $('#woocommerce_nimiq_gateway_nimiqx_api_key').closest('tr').removeClass('hidden');
-                break;
-            // case '': $('#conditional_field_id').closest('tr').removeClass('hidden'); break;
+            // case '':
+            //    $('#conditional_field_id').closest('tr').removeClass('hidden'); break;
+        }
+
+        validation_service = service_slug;
+        if (!is_setup) toggle_common_fields();
+    }
+
+    function toggle_common_fields() {
+        // Disable all conditional fields
+        var common_fields = [
+            '#woocommerce_nimiq_gateway_nimiqx_api_key',
+            // '#conditional_field_id',
+        ];
+        $(common_fields.join(',')).closest('tr').addClass('hidden');
+
+        // Enable required fields
+        if (price_service === 'nimiqx' || validation_service === 'nimiqx') {
+            $('#woocommerce_nimiq_gateway_nimiqx_api_key')
+                .closest('tr').removeClass('hidden');
         }
     }
 
-    $('#woocommerce_nimiq_gateway_validation_service').on('change', function(event) {
-        on_validation_service_change(event.target.value);
-    }).change();
+    // Set up event handlers
+    const $price_service_select = $('#woocommerce_nimiq_gateway_price_service');
+    const $validation_service_select = $('#woocommerce_nimiq_gateway_validation_service');
 
-    $('#woocommerce_nimiq_gateway_price_service').on('change', function(event) {
+    let price_service = $price_service_select.val();
+    let validation_service = $validation_service_select.val();
+
+    $price_service_select.on('change', function(event) {
         on_price_service_change(event.target.value);
-    }).change();
+    });
+
+    $validation_service_select.on('change', function(event) {
+        on_validation_service_change(event.target.value);
+    });
+
+    on_price_service_change(price_service, true);
+    on_validation_service_change(validation_service, true);
+    toggle_common_fields();
 })(jQuery);

--- a/price_services/coingecko.php
+++ b/price_services/coingecko.php
@@ -3,33 +3,32 @@ include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'interface.php' );
 
 class WC_Gateway_Nimiq_Price_Service_Coingecko implements WC_Gateway_Nimiq_Price_Service_Interface {
 
-	private $api_endpoint = 'https://api.coingecko.com/';
-	private $api_key = false;
+    private $api_endpoint = 'https://api.coingecko.com/';
+    private $api_key = false;
 
-	/**
-	 * Initializes the validation service
-	 *
-	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
-	 *
-	 * @return {void}
-	 */
-	public function __construct( $gateway ) {
-		$this->gateway = $gateway;
-	}
+    /**
+     * Initializes the validation service
+     *
+     * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+     * @return {void}
+     */
+    public function __construct( $gateway ) {
+        $this->gateway = $gateway;
+    }
 
-	/**
-	 * @param $currency
-	 *
-	 * @return float
-	 * @throws Exception
-	 */
-	public function getCurrentPrice( $currency ) {
-		$currency = strtolower( $currency );
-		$output   = file_get_contents( $this->api_endpoint . 'api/v3/coins/nimiq-2' );
-		$data     = json_decode( $output, true );
+    /**
+     * @param $currency
+     *
+     * @return float
+     * @throws Exception
+     */
+    public function getCurrentPrice( $currency ) {
+        $currency = strtolower( $currency );
+        $output   = file_get_contents( $this->api_endpoint . 'api/v3/coins/nimiq-2' );
+        $data     = json_decode( $output, true );
 
-		return ( $data['market_data']['current_price'][ $currency ] ) ? $data['market_data']['current_price'][ $currency ] : 0;
-	}
+        return ( $data['market_data']['current_price'][ $currency ] ) ? $data['market_data']['current_price'][ $currency ] : 0;
+    }
 }
 
 

--- a/price_services/coingecko.php
+++ b/price_services/coingecko.php
@@ -3,7 +3,7 @@ include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'interface.php' );
 
 class WC_Gateway_Nimiq_Price_Service_Coingecko implements WC_Gateway_Nimiq_Price_Service_Interface {
 
-    private $api_endpoint = 'https://api.coingecko.com/';
+    private $api_endpoint = 'https://api.coingecko.com/api/v3';
     private $api_key = false;
 
     /**
@@ -17,17 +17,30 @@ class WC_Gateway_Nimiq_Price_Service_Coingecko implements WC_Gateway_Nimiq_Price
     }
 
     /**
-     * @param $currency
-     *
-     * @return float
-     * @throws Exception
+     * @param {string} $currency
+     * @return {float}
      */
     public function getCurrentPrice( $currency ) {
         $currency = strtolower( $currency );
-        $output   = file_get_contents( $this->api_endpoint . 'api/v3/coins/nimiq-2' );
-        $data     = json_decode( $output, true );
+        $api_response = wp_remote_get( $this->api_endpoint . '/simple/price?ids=nimiq-2&vs_currencies=' . $currency );
 
-        return ( $data['market_data']['current_price'][ $currency ] ) ? $data['market_data']['current_price'][ $currency ] : 0;
+        if ( is_wp_error( $api_response ) ) {
+            return $api_response;
+        }
+
+        $result = json_decode( $api_response[ 'body' ], true );
+
+        if ( $result->error ) {
+            return new WP_Error( 'service', $result->error );
+        }
+
+        $price = $result['nimiq-2'][ $currency ];
+
+        if ( empty( $price ) ) {
+            return new WP_Error( 'service', 'The currency ' . strtoupper( $currency ) . ' is not supported by Coingecko.' );
+        };
+
+        return $price;
     }
 }
 

--- a/price_services/coingecko.php
+++ b/price_services/coingecko.php
@@ -1,0 +1,35 @@
+<?php
+include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'interface.php' );
+
+class WC_Gateway_Nimiq_Price_Service_Coingecko implements WC_Gateway_Nimiq_Price_Service_Interface {
+
+	private $api_endpoint = 'https://api.coingecko.com/';
+	private $api_key = false;
+
+	/**
+	 * Initializes the validation service
+	 *
+	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+	 *
+	 * @return {void}
+	 */
+	public function __construct( $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * @param $currency
+	 *
+	 * @return float
+	 * @throws Exception
+	 */
+	public function getCurrentPrice( $currency ) {
+		$currency = strtolower( $currency );
+		$output   = file_get_contents( $this->api_endpoint . 'api/v3/coins/nimiq-2' );
+		$data     = json_decode( $output, true );
+
+		return ( $data['market_data']['current_price'][ $currency ] ) ? $data['market_data']['current_price'][ $currency ] : 0;
+	}
+}
+
+

--- a/price_services/interface.php
+++ b/price_services/interface.php
@@ -1,0 +1,22 @@
+<?php
+
+interface WC_Gateway_Nimiq_Price_Service_Interface {
+	/**
+	 * Initializes the validation service
+	 *
+	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+	 *
+	 * @return {void}
+	 */
+	public function __construct( $gateway );
+
+
+	/**
+	 * Retrieves the current nimiq price
+	 *
+	 * @param {string} The currency
+	 *
+	 * @return {float|WP_Error}
+	 */
+	public function getCurrentPrice( $currency );
+}

--- a/price_services/interface.php
+++ b/price_services/interface.php
@@ -1,22 +1,22 @@
 <?php
 
 interface WC_Gateway_Nimiq_Price_Service_Interface {
-	/**
-	 * Initializes the validation service
-	 *
-	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
-	 *
-	 * @return {void}
-	 */
-	public function __construct( $gateway );
+    /**
+     * Initializes the validation service
+     *
+     * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+     *
+     * @return {void}
+     */
+    public function __construct( $gateway );
 
 
-	/**
-	 * Retrieves the current nimiq price
-	 *
-	 * @param {string} The currency
-	 *
-	 * @return {float|WP_Error}
-	 */
-	public function getCurrentPrice( $currency );
+    /**
+     * Retrieves the current nimiq price
+     *
+     * @param {string} The currency
+     *
+     * @return {float|WP_Error}
+     */
+    public function getCurrentPrice( $currency );
 }

--- a/price_services/interface.php
+++ b/price_services/interface.php
@@ -5,7 +5,6 @@ interface WC_Gateway_Nimiq_Price_Service_Interface {
      * Initializes the validation service
      *
      * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
-     *
      * @return {void}
      */
     public function __construct( $gateway );
@@ -14,8 +13,7 @@ interface WC_Gateway_Nimiq_Price_Service_Interface {
     /**
      * Retrieves the current nimiq price
      *
-     * @param {string} The currency
-     *
+     * @param {string} The currency to get the price for
      * @return {float|WP_Error}
      */
     public function getCurrentPrice( $currency );

--- a/price_services/nimiqx.php
+++ b/price_services/nimiqx.php
@@ -1,0 +1,39 @@
+<?php
+include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'interface.php' );
+
+class WC_Gateway_Nimiq_Price_Service_Nimiqx implements WC_Gateway_Nimiq_Price_Service_Interface {
+
+	private $api_endpoint = 'https://api.nimiqx.com/';
+	private $api_key = false;
+
+	/**
+	 * Initializes the validation service
+	 *
+	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+	 *
+	 * @return {void}
+	 */
+	public function __construct( $gateway ) {
+		$this->gateway = $gateway;
+		$this->api_key = $gateway->get_option( 'nimiqx_api_key' );
+	}
+
+	/**
+	 * @param $currency
+	 *
+	 * @return float
+	 * @throws Exception
+	 */
+	public function getCurrentPrice( $currency ) {
+		if ( ! $this->api_key ) {
+			throw new Exception( new WP_Error( 'Invalid NimiqX api key!' ) );
+		}
+		$currency = strtolower( $currency );
+		$output   = file_get_contents( $this->api_endpoint . 'price/btc,' . $currency . '?api_key=' . $this->api_key );
+		$data     = json_decode( $output, true );
+
+		return ( $data[ $currency ] ) ? $data[ $currency ] : 0;
+	}
+}
+
+

--- a/price_services/nimiqx.php
+++ b/price_services/nimiqx.php
@@ -3,37 +3,37 @@ include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'interface.php' );
 
 class WC_Gateway_Nimiq_Price_Service_Nimiqx implements WC_Gateway_Nimiq_Price_Service_Interface {
 
-	private $api_endpoint = 'https://api.nimiqx.com/';
-	private $api_key = false;
+    private $api_endpoint = 'https://api.nimiqx.com/';
+    private $api_key = false;
 
-	/**
-	 * Initializes the validation service
-	 *
-	 * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
-	 *
-	 * @return {void}
-	 */
-	public function __construct( $gateway ) {
-		$this->gateway = $gateway;
-		$this->api_key = $gateway->get_option( 'nimiqx_api_key' );
-	}
+    /**
+     * Initializes the validation service
+     *
+     * @param {WC_Gateway_Nimiq} $gateway - A WC_Gateway_Nimiq class instance
+     *
+     * @return {void}
+     */
+    public function __construct( $gateway ) {
+        $this->gateway = $gateway;
+        $this->api_key = $gateway->get_option( 'nimiqx_api_key' );
+    }
 
-	/**
-	 * @param $currency
-	 *
-	 * @return float
-	 * @throws Exception
-	 */
-	public function getCurrentPrice( $currency ) {
-		if ( ! $this->api_key ) {
-			throw new Exception( new WP_Error( 'Invalid NimiqX api key!' ) );
-		}
-		$currency = strtolower( $currency );
-		$output   = file_get_contents( $this->api_endpoint . 'price/btc,' . $currency . '?api_key=' . $this->api_key );
-		$data     = json_decode( $output, true );
+    /**
+     * @param $currency
+     *
+     * @return float
+     * @throws Exception
+     */
+    public function getCurrentPrice( $currency ) {
+        if ( ! $this->api_key ) {
+            throw new Exception( new WP_Error( 'Invalid NimiqX api key!' ) );
+        }
+        $currency = strtolower( $currency );
+        $output   = file_get_contents( $this->api_endpoint . 'price/btc,' . $currency . '?api_key=' . $this->api_key );
+        $data     = json_decode( $output, true );
 
-		return ( $data[ $currency ] ) ? $data[ $currency ] : 0;
-	}
+        return ( $data[ $currency ] ) ? $data[ $currency ] : 0;
+    }
 }
 
 

--- a/validation_services/nimiqx.php
+++ b/validation_services/nimiqx.php
@@ -59,7 +59,13 @@ class WC_Gateway_Nimiq_Service_NimiqX implements WC_Gateway_Nimiq_Service_Interf
             return $api_response;
         }
 
-        $this->transaction = json_decode( $api_response[ 'body' ] );
+        $transaction = json_decode( $api_response[ 'body' ] );
+
+        if ( $transaction->error ) {
+            return new WP_Error( 'service', $transaction->error );
+        }
+
+        $this->transaction = $transaction;
     }
 
     /**

--- a/woocommerce-gateway-nimiq.php
+++ b/woocommerce-gateway-nimiq.php
@@ -199,8 +199,9 @@ function wc_nimiq_gateway_init() {
 				'validation_interval' => array(
 					'title'       => __( 'Validation interval', 'wc-gateway-nimiq' ),
 					'type'        => 'number',
-					'description' => __( 'Interval in minutes to validate transactions. If you change this, disable and enable to make the change in effect.', 'wc-gateway-nimiq' ),
-					'default'     => 15,
+					'description' => __( 'Interval in minutes to validate transactions. If you change this, disable and enable this plugin to put the change into effect.', 'wc-gateway-nimiq' ),
+					'default'     => 30,
+					'placeholder' => 'Default: 30',
 					'desc_tip'    => true,
 				),
 

--- a/woocommerce-gateway-nimiq.php
+++ b/woocommerce-gateway-nimiq.php
@@ -167,10 +167,11 @@ function wc_nimiq_gateway_init() {
 					'placeholder' => 'NQ...',
 					'desc_tip'    => true,
 				),
+
 				'price_service' => array(
 					'title'       => __( 'Price Service', 'wc-gateway-nimiq' ),
 					'type'        => 'select',
-					'description' => __( 'Which service to use for fetching price information.', 'wc-gateway-nimiq' ),
+					'description' => __( 'Which service to use for fetching price information for automatic currency conversion.', 'wc-gateway-nimiq' ),
 					'default'     => 'none',
 					'options'     => array(
 						// List available price services here. The option value must match the file name.
@@ -180,6 +181,7 @@ function wc_nimiq_gateway_init() {
 					),
 					'desc_tip'    => true,
 				),
+
 				'validation_service' => array(
 					'title'       => __( 'Validation Service', 'wc-gateway-nimiq' ),
 					'type'        => 'select',
@@ -199,15 +201,6 @@ function wc_nimiq_gateway_init() {
 					'type'        => 'number',
 					'description' => __( 'Interval in minutes to validate transactions. If you change this, disable and enable to make the change in effect.', 'wc-gateway-nimiq' ),
 					'default'     => 15,
-					'desc_tip'    => true,
-				),
-
-				'nimiqx_api_key' => array(
-					'title'       => __( 'NimiqX API Key', 'wc-gateway-nimiq' ),
-					'type'        => 'text',
-					'description' => __( 'NimiqX is used to convert the order amount to NIM when currency is not NIM', 'wc-gateway-nimiq' ),
-					'default'     => '',
-					'placeholder' => '',
 					'desc_tip'    => true,
 				),
 
@@ -237,13 +230,15 @@ function wc_nimiq_gateway_init() {
 					'placeholder' => __( '', 'wc-gateway-nimiq' ),
 					'desc_tip'    => true,
 				),
-        
+
 				'nimiqx_api_key' => array(
 					'title'       => __( 'NimiqX API Key', 'wc-gateway-nimiq' ),
 					'type'        => 'text',
-					'description' => __( 'Token for accessing the NimiqX validation service.', 'wc-gateway-nimiq' ),
-					'placeholder' => __( 'This field is required.' ),
-					'desc_tip'    => true, 
+					'description' => __( 'Token for accessing the NimiqX price and validation service.', 'wc-gateway-nimiq' ),
+					'default'     => '',
+					'placeholder' => __( 'This field is required.', 'wc-gateway-nimiq' ),
+					'desc_tip'    => true,
+				),
 
 				'rpc_behavior' => array(
 					'title'       => __( 'Behavior', 'wc-gateway-nimiq' ),

--- a/woocommerce-gateway-nimiq.php
+++ b/woocommerce-gateway-nimiq.php
@@ -168,6 +168,18 @@ function wc_nimiq_gateway_init() {
 					'desc_tip'    => true,
 				),
 
+				'price_service' => array(
+					'title'       => __( 'Price Service', 'wc-gateway-nimiq' ),
+					'type'        => 'select',
+					'description' => __( 'Which service to use for fetching price information.', 'wc-gateway-nimiq' ),
+					'default'     => 'none',
+					'options'     => array(
+						// List available price services here. The option value must match the file name.
+						'none' => 'None',
+						'nimiqx' => 'NimiqX',
+					),
+					'desc_tip'    => true,
+				),
 				'validation_service' => array(
 					'title'       => __( 'Validation Service', 'wc-gateway-nimiq' ),
 					'type'        => 'select',
@@ -179,6 +191,15 @@ function wc_nimiq_gateway_init() {
 						'json_rpc'    => 'Nimiq JSON-RPC API',
 						'nimiqx'      => 'NimiqX (mainnet)',
 					),
+					'desc_tip'    => true,
+				),
+
+				'nimiqx_api_key' => array(
+					'title'       => __( 'NimiqX API Key', 'wc-gateway-nimiq' ),
+					'type'        => 'text',
+					'description' => __( 'NimiqX is used to convert the order amount to NIM when currency is not NIM', 'wc-gateway-nimiq' ),
+					'default'     => '',
+					'placeholder' => '',
 					'desc_tip'    => true,
 				),
 

--- a/woocommerce-gateway-nimiq.php
+++ b/woocommerce-gateway-nimiq.php
@@ -196,17 +196,8 @@ function wc_nimiq_gateway_init() {
 					'desc_tip'    => true,
 				),
 
-				'validation_interval' => array(
-					'title'       => __( 'Validation interval', 'wc-gateway-nimiq' ),
-					'type'        => 'number',
-					'description' => __( 'Interval in minutes to validate transactions. If you change this, disable and enable this plugin to put the change into effect.', 'wc-gateway-nimiq' ),
-					'default'     => 30,
-					'placeholder' => 'Default: 30',
-					'desc_tip'    => true,
-				),
-
 				'jsonrpc_url' => array(
-					'title'       => __( 'Validation JSON-RPC URL', 'wc-gateway-nimiq' ),
+					'title'       => __( 'JSON-RPC URL', 'wc-gateway-nimiq' ),
 					'type'        => 'text',
 					'description' => __( 'URL (including port) of the JSON-RPC server used to verify transactions.', 'wc-gateway-nimiq' ),
 					'default'     => 'http://localhost:8648',
@@ -215,7 +206,7 @@ function wc_nimiq_gateway_init() {
 				),
 
 				'jsonrpc_username' => array(
-					'title'       => __( 'Validation JSON-RPC Username', 'wc-gateway-nimiq' ),
+					'title'       => __( 'JSON-RPC Username', 'wc-gateway-nimiq' ),
 					'type'        => 'text',
 					'description' => __( '(Optional) Username for the protected JSON-RPC service', 'wc-gateway-nimiq' ),
 					'default'     => '',
@@ -224,7 +215,7 @@ function wc_nimiq_gateway_init() {
 				),
 
 				'jsonrpc_password' => array(
-					'title'       => __( 'Validation JSON-RPC Password', 'wc-gateway-nimiq' ),
+					'title'       => __( 'JSON-RPC Password', 'wc-gateway-nimiq' ),
 					'type'        => 'text',
 					'description' => __( '(Optional) Password for the protected JSON-RPC service', 'wc-gateway-nimiq' ),
 					'default'     => '',
@@ -238,6 +229,15 @@ function wc_nimiq_gateway_init() {
 					'description' => __( 'Token for accessing the NimiqX price and validation service.', 'wc-gateway-nimiq' ),
 					'default'     => '',
 					'placeholder' => __( 'This field is required.', 'wc-gateway-nimiq' ),
+					'desc_tip'    => true,
+				),
+
+				'validation_interval' => array(
+					'title'       => __( 'Validation Interval', 'wc-gateway-nimiq' ),
+					'type'        => 'number',
+					'description' => __( 'Interval in minutes to validate transactions. If you change this, disable and enable this plugin to put the change into effect.', 'wc-gateway-nimiq' ),
+					'default'     => 30,
+					'placeholder' => 'Default: 30',
 					'desc_tip'    => true,
 				),
 
@@ -332,30 +332,40 @@ function wc_nimiq_gateway_init() {
 
 			// These scripts are enqueued at the end of the page
 			wp_enqueue_script('HubApi', plugin_dir_url( __FILE__ ) . 'js/HubApi.standalone.umd.js', [], $this->version(), true );
-			$order_total = 0;
-			$order_hash = '';
+
+			$order_total_nim = 0;
 			$nim_price = 0;
+			$order_currency = '';
+			$order_hash = '';
 			if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
 				$order_id = wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) );
 				$order = wc_get_order( $order_id );
 				$order_total = $order->get_total();
 				$order_currency = $order->get_currency();
-				$price_service  = $this->get_option( 'price_service' );
+				$price_service = $this->get_option( 'price_service' );
 
-				update_post_meta( $order_id, 'order_total_in_nim', $order_total );
-				if ( $order_currency !== 'NIM' && $price_service !== 'none' ) {
-					// @TODO: Fetch price info from some api
+				if ( $order_currency === 'NIM') {
+					$order_total_nim = $order_total;
+					update_post_meta( $order_id, 'order_total_nim', $order_total_nim );
+				} elseif ( $price_service !== 'none' ) {
 					include_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'price_services' . DIRECTORY_SEPARATOR . $price_service . '.php' );
 					$class = 'WC_Gateway_Nimiq_Price_Service_' . ucfirst( $price_service );
 
 					$price_service = new $class( $this );
-					$nim_price     = $price_service->getCurrentPrice( $order_currency );
-					$order_total   = $order_total / $nim_price;
+					$nim_price = $price_service->getCurrentPrice( $order_currency );
 
-					error_log( 'Fetching Nimiq price info' );
-					update_post_meta( $order_id, 'nim_price', $nim_price );
-					update_post_meta( $order_id, 'nim_price_currency', $order_currency );
-					update_post_meta( $order_id, 'order_total_in_nim', $order_total );
+					if ( is_wp_error( $nim_price ) ) {
+						update_post_meta( $order_id, 'conversion_error', $nim_price->get_error_message() );
+					} else {
+						// Round up to full NIM
+						$order_total_nim = ceil( $order_total / $nim_price );
+
+						update_post_meta( $order_id, 'nim_price', $nim_price );
+						update_post_meta( $order_id, 'nim_price_currency', $order_currency );
+						update_post_meta( $order_id, 'order_total_nim', $order_total_nim );
+					}
+				} else {
+					$nim_price = new WP_Error( 'connection', 'No price conversion service configured.' );
 				}
 
 				$order_hash = $order->get_meta( 'order_hash' );
@@ -378,7 +388,7 @@ function wc_nimiq_gateway_init() {
 				'HUB_URL'        => $this->get_option( 'network' ) === 'main' ? 'https://hub.nimiq.com/' : 'https://hub.nimiq-testnet.com/',
 				'SHOP_LOGO_URL'  => $this->get_option( 'shop_logo_url' ),
 				'STORE_ADDRESS'  => $this->get_option( 'nimiq_address' ),
-				'ORDER_TOTAL'    => intval( floatval( $order_total ) * 1e5 ),
+				'ORDER_TOTAL'    => intval( $order_total_nim * 1e5 ),
 				'TX_FEE'         => ( 166 + count( $tx_message_bytes ) ) * ( intval( $this->get_option( 'fee' ) ) ?: 0 ),
 				'TX_MESSAGE'     => '[' . implode( ',', $tx_message_bytes ) . ']',
 				'RPC_BEHAVIOR'   => $this->get_option( 'rpc_behavior' ),
@@ -394,13 +404,24 @@ function wc_nimiq_gateway_init() {
 				<input type="hidden" name="customer_nim_address" id="customer_nim_address" value="">
 
 				<p class="form-row">
-                    Your order amount is: <?= number_format( $order_total, 2, '.', ' ' ); ?> NIM.<br/>
-					<?php if ( $nim_price !== 0 ): ?>
-                        Conversion rate: 1 NIM = <?= wc_price( $nim_price, [ 'decimals' => 5 ] ); ?>
-                        <br/>
-					<?php endif; ?>
-                    Please click the big button below to pay with Nimiq.
-                </p>
+					Order amount: <strong><?php echo( number_format( $order_total_nim, 0, '.', ' ' ) ); ?> NIM</strong>
+				</p>
+
+				<?php if ( is_wp_error( $nim_price ) ) { ?>
+					<p class="form-row" style="color: red;">
+						<em>Could not get a NIM conversion rate:<br><?php echo( $nim_price->get_error_message() ); ?></em>
+					</p>
+				<?php } elseif ( $nim_price > 0 ) { ?>
+					<p class="form-row">
+						Rate: 1 NIM = <?php echo( wc_price( $nim_price, [ 'decimals' => 6, 'currency' => $order_currency ] ) ); ?>
+					</p>
+				<?php } ?>
+
+				<?php if ( ! is_wp_error( $nim_price ) && $nim_price > 0 || $order_currency === 'NIM') { ?>
+					<p class="form-row">
+						Please click the big button below to pay with Nimiq.
+					</p>
+				<?php } ?>
 			</div>
 
 			<div id="nim_payment_complete_block" class="hidden">

--- a/woocommerce-gateway-nimiq.php
+++ b/woocommerce-gateway-nimiq.php
@@ -307,13 +307,21 @@ function wc_nimiq_gateway_init() {
 
 			// These scripts are enqueued at the end of the page
 			wp_enqueue_script('HubApi', plugin_dir_url( __FILE__ ) . 'js/HubApi.standalone.umd.js', [], $this->version(), true );
-
 			$order_total = 0;
 			$order_hash = '';
 			if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
 				$order_id = wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) );
 				$order = wc_get_order( $order_id );
 				$order_total = $order->get_total();
+				$order_currency = $order->get_currency();
+
+				update_post_meta( $order_id, 'order_total_in_nim', $order_total );
+				if( $order_currency !== 'NIM' ) {
+				    // @TODO: Fetch price info from some api
+                    error_log('Fetching Nimiq price info');
+					update_post_meta( $order_id, 'nim_price', $order_hash );
+					update_post_meta( $order_id, 'order_total_in_nim', $order_total );
+				}
 
 				$order_hash = $order->get_meta( 'order_hash' );
 				if ( empty( $order_hash ) ) {


### PR DESCRIPTION
Currently when a user checkout, the displayed price is also the amount in NIM.
$1 = 1 nim or €1 = 1 nim, however since this is not the case some conversion has to take place.

This PR implements a price service interface and 2 price services where Wordpress pulls the price info from.
Currently NimiqX and Coingecko are supported.

When enabled, the checkout amount is converted to NIM and that amount is used upon checkout & validation.

Fixes #1 